### PR TITLE
fix: add folder usage descriptions to stop repeated TCC prompts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,14 @@ jobs:
               <true/>
               <key>NSHighResolutionCapable</key>
               <true/>
+              <key>NSDesktopFolderUsageDescription</key>
+              <string>GitPeek needs access to your Desktop folder to monitor Git repositories stored there.</string>
+              <key>NSDocumentsFolderUsageDescription</key>
+              <string>GitPeek needs access to your Documents folder to monitor Git repositories stored there.</string>
+              <key>NSDownloadsFolderUsageDescription</key>
+              <string>GitPeek needs access to your Downloads folder to monitor Git repositories stored there.</string>
+              <key>NSRemovableVolumesUsageDescription</key>
+              <string>GitPeek needs access to removable volumes to monitor Git repositories stored there.</string>
               <key>SUFeedURL</key>
               <string>https://raw.githubusercontent.com/ryota-kishimoto/gitpeek/main/appcast.xml</string>
               <key>SUEnableAutomaticChecks</key>

--- a/GitPeek/Info.plist
+++ b/GitPeek/Info.plist
@@ -26,6 +26,14 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2024 GitPeek. All rights reserved.</string>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>GitPeek needs access to your Desktop folder to monitor Git repositories stored there.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>GitPeek needs access to your Documents folder to monitor Git repositories stored there.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>GitPeek needs access to your Downloads folder to monitor Git repositories stored there.</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>GitPeek needs access to removable volumes to monitor Git repositories stored there.</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUFeedURL</key>

--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,14 @@ cat > GitPeek.app/Contents/Info.plist << EOF
     <true/>
     <key>NSSupportsAutomaticTermination</key>
     <false/>
+    <key>NSDesktopFolderUsageDescription</key>
+    <string>GitPeek needs access to your Desktop folder to monitor Git repositories stored there.</string>
+    <key>NSDocumentsFolderUsageDescription</key>
+    <string>GitPeek needs access to your Documents folder to monitor Git repositories stored there.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>GitPeek needs access to your Downloads folder to monitor Git repositories stored there.</string>
+    <key>NSRemovableVolumesUsageDescription</key>
+    <string>GitPeek needs access to removable volumes to monitor Git repositories stored there.</string>
     <key>SUFeedURL</key>
     <string>https://raw.githubusercontent.com/ryota-kishimoto/gitpeek/main/appcast.xml</string>
     <key>SUEnableAutomaticChecks</key>


### PR DESCRIPTION
## Summary
- macOS が起動のたびに「デスクトップ内のファイルへのアクセスを求めています」系ダイアログを無限に表示する不具合を修正
- Info.plist に `NSDesktopFolderUsageDescription` / `NSDocumentsFolderUsageDescription` / `NSDownloadsFolderUsageDescription` / `NSRemovableVolumesUsageDescription` を追加

## 原因
GitPeek は `Process` 経由で `git` コマンドを Desktop/Documents/Downloads などの保護フォルダ配下のリポジトリに対して実行する。Info.plist に usage description key が 1 つもないと、macOS TCC は説明文なしでプロンプトを出し、ユーザーの許可決定が安定して記録されないため、`GitMonitor` がタイマーでリフレッシュするたびに再度ダイアログが出てしまう。

## 変更点
Info.plist を生成する 3 箇所すべてに同じ keys を追加:
- `GitPeek/Info.plist` (source)
- `build.sh` (ローカルビルド)
- `.github/workflows/release.yml` (リリースビルド)

## Test plan
- [ ] `./build.sh` でビルドした `GitPeek.app` を起動し、Desktop 配下のリポジトリを登録
- [ ] フォルダアクセスダイアログに説明文が表示されることを確認
- [ ] 一度「OK」した後、アプリを再起動してもダイアログが再び出ないことを確認
- [ ] 10 秒間隔の自動リフレッシュが走ってもダイアログが出ないことを確認
- [ ] Documents / Downloads 配下のリポジトリでも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)