### PR TITLE
fix: unbreak CI test job (actor-isolation, notification crash, stale test)

### DIFF
--- a/GitPeek/Models/RepositoryStore.swift
+++ b/GitPeek/Models/RepositoryStore.swift
@@ -58,39 +58,44 @@ final class RepositoryStore: ObservableObject {
     /// - Parameter id: Repository ID to update
     /// - Parameter shouldFetch: Whether to fetch from remote (default: false for speed)
     func updateRepository(_ id: UUID, shouldFetch: Bool = false) async {
-        guard let index = repositories.firstIndex(where: { $0.id == id }) else { return }
-
-        let repository = repositories[index]
+        guard let repository = repositories.first(where: { $0.id == id }) else { return }
+        let path = repository.path
 
         do {
             // Run fast local git commands in parallel
-            async let status = gitCommand.getStatus(at: repository.path)
-            async let branch = gitCommand.getCurrentBranch(at: repository.path)
-            async let remoteURL = gitCommand.getRemoteURL(at: repository.path)
-            async let worktrees = gitCommand.getWorktrees(at: repository.path)
-            async let commitDiff = gitCommand.getCommitDifference(at: repository.path)
+            async let status = gitCommand.getStatus(at: path)
+            async let branch = gitCommand.getCurrentBranch(at: path)
+            async let remoteURL = gitCommand.getRemoteURL(at: path)
+            async let worktrees = gitCommand.getWorktrees(at: path)
+            async let commitDiff = gitCommand.getCommitDifference(at: path)
 
             // Wait for all results
             let (statusResult, branchResult, remoteURLResult, worktreesResult, commitDiffResult) =
                 try await (status, branch, remoteURL, worktrees, commitDiff)
 
-            repositories[index].updateStatus(statusResult, branch: branchResult)
-            repositories[index].updateRemoteURL(remoteURLResult)
-            repositories[index].updateWorktrees(worktreesResult)
-            repositories[index].updateCommitDifference(behind: commitDiffResult.behind, ahead: commitDiffResult.ahead)
+            if let index = repositories.firstIndex(where: { $0.id == id }) {
+                var updated = repositories[index]
+                updated.updateStatus(statusResult, branch: branchResult)
+                updated.updateRemoteURL(remoteURLResult)
+                updated.updateWorktrees(worktreesResult)
+                updated.updateCommitDifference(behind: commitDiffResult.behind, ahead: commitDiffResult.ahead)
+                repositories[index] = updated
+            }
 
             // Optionally fetch in background (slow, but updates remote info)
             if shouldFetch {
                 Task {
-                    try? await gitCommand.fetch(at: repository.path)
+                    try? await gitCommand.fetch(at: path)
                     // Re-check commit difference after fetch
-                    if let newCommitDiff = try? await gitCommand.getCommitDifference(at: repository.path) {
+                    if let newCommitDiff = try? await gitCommand.getCommitDifference(at: path) {
                         await MainActor.run {
                             if let currentIndex = repositories.firstIndex(where: { $0.id == id }) {
-                                repositories[currentIndex].updateCommitDifference(
+                                var updated = repositories[currentIndex]
+                                updated.updateCommitDifference(
                                     behind: newCommitDiff.behind,
                                     ahead: newCommitDiff.ahead
                                 )
+                                repositories[currentIndex] = updated
                             }
                         }
                     }
@@ -125,18 +130,27 @@ final class RepositoryStore: ObservableObject {
             throw RepositoryError.notFound
         }
 
+        let path = repositories[index].path
+
         // Set pulling state
-        repositories[index].isPulling = true
+        setPulling(id: id, value: true)
 
         do {
-            let result = try await gitCommand.pull(at: repositories[index].path)
+            let result = try await gitCommand.pull(at: path)
             await updateRepository(id)
-            repositories[index].isPulling = false
+            setPulling(id: id, value: false)
             return result
         } catch {
-            repositories[index].isPulling = false
+            setPulling(id: id, value: false)
             throw error
         }
+    }
+
+    private func setPulling(id: UUID, value: Bool) {
+        guard let index = repositories.firstIndex(where: { $0.id == id }) else { return }
+        var updated = repositories[index]
+        updated.isPulling = value
+        repositories[index] = updated
     }
     
     /// Clears all repositories

--- a/GitPeek/Models/RepositoryStore.swift
+++ b/GitPeek/Models/RepositoryStore.swift
@@ -84,20 +84,15 @@ final class RepositoryStore: ObservableObject {
 
             // Optionally fetch in background (slow, but updates remote info)
             if shouldFetch {
-                Task {
+                Task { @MainActor in
                     try? await gitCommand.fetch(at: path)
                     // Re-check commit difference after fetch
                     if let newCommitDiff = try? await gitCommand.getCommitDifference(at: path) {
-                        await MainActor.run {
-                            if let currentIndex = repositories.firstIndex(where: { $0.id == id }) {
-                                var updated = repositories[currentIndex]
-                                updated.updateCommitDifference(
-                                    behind: newCommitDiff.behind,
-                                    ahead: newCommitDiff.ahead
-                                )
-                                repositories[currentIndex] = updated
-                            }
-                        }
+                        self.applyCommitDifference(
+                            id: id,
+                            behind: newCommitDiff.behind,
+                            ahead: newCommitDiff.ahead
+                        )
                     }
                 }
             }
@@ -150,6 +145,13 @@ final class RepositoryStore: ObservableObject {
         guard let index = repositories.firstIndex(where: { $0.id == id }) else { return }
         var updated = repositories[index]
         updated.isPulling = value
+        repositories[index] = updated
+    }
+
+    private func applyCommitDifference(id: UUID, behind: Int, ahead: Int) {
+        guard let index = repositories.firstIndex(where: { $0.id == id }) else { return }
+        var updated = repositories[index]
+        updated.updateCommitDifference(behind: behind, ahead: ahead)
         repositories[index] = updated
     }
     

--- a/GitPeek/Utils/GitMonitor.swift
+++ b/GitPeek/Utils/GitMonitor.swift
@@ -109,11 +109,28 @@ final class GitMonitor: ObservableObject {
     // MARK: - Notifications
 
     private func requestNotificationPermission() {
+        // UNUserNotificationCenter requires a bundled app and crashes with
+        // "bundleProxyForCurrentProcess is nil" when invoked from a unit-test
+        // host (either XCTest via Xcode or swift-test). Skip in any test run.
+        if Self.isRunningInTests {
+            return
+        }
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error = error {
                 Logger.debug("[GitMonitor] Notification permission error: \(error)")
             }
         }
+    }
+
+    private static var isRunningInTests: Bool {
+        if NSClassFromString("XCTestCase") != nil {
+            return true
+        }
+        let env = ProcessInfo.processInfo.environment
+        if env["XCTestConfigurationFilePath"] != nil || env["XCTestBundlePath"] != nil {
+            return true
+        }
+        return false
     }
 
     private func checkAndNotify(repository: Repository, oldStatus: GitStatus?, newStatus: GitStatus) {

--- a/GitPeekTests/Snapshot/ViewSnapshotTests.swift
+++ b/GitPeekTests/Snapshot/ViewSnapshotTests.swift
@@ -81,34 +81,4 @@ final class ViewSnapshotTests: XCTestCase {
         assertSnapshot(of: hostingController, as: .image)
     }
     
-    // MARK: - Content View Tests
-    
-    func testContentView_Empty() async {
-        let store = RepositoryStore()
-        let view = ContentView()
-            .environmentObject(store)
-            .frame(width: 600, height: 400)
-        
-        let hostingController = NSHostingController(rootView: view)
-        hostingController.view.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
-        hostingController.view.needsLayout = true
-        hostingController.view.layoutSubtreeIfNeeded()
-        
-        assertSnapshot(of: hostingController, as: .image)
-    }
-    
-    func testContentView_DarkMode() async {
-        let store = RepositoryStore()
-        let view = ContentView()
-            .environmentObject(store)
-            .frame(width: 600, height: 400)
-            .environment(\.colorScheme, .dark)
-        
-        let hostingController = NSHostingController(rootView: view)
-        hostingController.view.frame = NSRect(x: 0, y: 0, width: 600, height: 400)
-        hostingController.view.needsLayout = true
-        hostingController.view.layoutSubtreeIfNeeded()
-        
-        assertSnapshot(of: hostingController, as: .image)
-    }
 }


### PR DESCRIPTION
## Summary
main の CI test ジョブが複数の独立した原因で赤になっていたのを全部直す。ローカルで `swift test --skip ViewSnapshotTests`（CIと同じコマンド）が **37 tests / 0 failures** で通ることを確認済み。

## 原因と修正

### 1. `RepositoryStore.swift`: actor-isolation コンパイルエラー
\`\`\`
error: actor-isolated property 'repositories' cannot be passed 'inout'
to 'async' function call
\`\`\`
`@MainActor` クラスの `@Published var repositories` に対して、async 関数の中で `repositories[index].updateStatus(…)` のような mutating メソッドを呼んでいた（`Repository` は struct）。Swift 5.9 はこれを subscript 経由の inout アクセスと見なし、async 境界を跨ぐと拒否する。

**修正**: ローカルにコピーしてから mutate、配列に代入し直すパターンに書き換え。
\`\`\`swift
var updated = repositories[index]
updated.updateStatus(…)
repositories[index] = updated
\`\`\`
`pullRepository` 内の await を跨ぐ `.path` 読み取りも、事前に local 変数に退避。

### 2. `GitMonitor.swift`: テスト実行時に `UNUserNotificationCenter` がクラッシュ
コンパイルを通したあと、今度はランタイムで `ExternalAppIntegrationTests` の setUp が `bundleProxyForCurrentProcess is nil` で落ちていた。`MenuBarViewModel.init` → `GitMonitor.init` → `requestNotificationPermission()` という経路で、bundle を持たない xctest プロセスから UNUserNotificationCenter を叩くと落ちる仕様。

**修正**: テスト環境検出を入れてスキップ。`NSClassFromString(\"XCTestCase\")` に加えて `XCTestConfigurationFilePath` / `XCTestBundlePath` 環境変数も見るので、Xcode 経由 / swift-test 経由のどちらでも効く。

### 3. `ViewSnapshotTests.swift`: 存在しない `ContentView` を参照
\`\`\`
error: cannot find 'ContentView' in scope
\`\`\`
トップレベルビューは既に `MenuBarView` に置き換わっていて、それは `testMenuBarView_Empty/_DarkMode` で既にカバーされている。古い `testContentView_Empty/_DarkMode` 2 件を削除。

## Test plan
- [x] `swift build` がローカルで通る
- [x] `swift test --skip ViewSnapshotTests` が 37 tests / 0 failures で通る（CI の test ジョブ相当）
- [ ] CI の Test ジョブが緑になる
- [ ] CI の Snapshot Tests ジョブが引き続き緑（触っていない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)