### PR TITLE
chore: add .mcp.json.example with XcodeBuildMCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ docs/.jekyll-cache/
 *.backup
 tmp/
 temp/
+
+# Claude Code MCP (per-developer; see .mcp.json.example)
+.mcp.json

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "XcodeBuildMCP": {
+      "command": "npx",
+      "args": ["-y", "xcodebuildmcp@latest", "mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Claude Code 用のプロジェクトスコープ MCP 設定のテンプレを追加。`cp .mcp.json.example .mcp.json` だけで **XcodeBuildMCP** が有効になる。

## XcodeBuildMCP とは
[getsentry/XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP)。`xcodebuild` / シミュレータ / scheme / bundle 周りのツールを MCP 経由で Claude に提供する。今回の CI 修復みたいに `xcodebuild test` の結果を手で grep する代わりに、構造化されたツールとして呼べる。

## 追加したもの
- `.mcp.json.example`: npx 起動の最小設定。エントリ名は `XcodeBuildMCP`
  \`\`\`json
  {
    "mcpServers": {
      "XcodeBuildMCP": {
        "command": "npx",
        "args": ["-y", "xcodebuildmcp@latest", "mcp"]
      }
    }
  }
  \`\`\`
- `.gitignore`: 実体の `.mcp.json` を無視（開発者ごとに個人用サーバーや API キーを足すことがあるので流出させない）

## 前提
- Node.js 18+（ローカルは v22 確認済み）
- Xcode と Command Line Tools

## 使い方
\`\`\`bash
cp .mcp.json.example .mcp.json
# Claude Code を再起動すると XcodeBuildMCP が読み込まれる
\`\`\`

## Test plan
- [x] `npm view xcodebuildmcp` でパッケージの存在と正しいレポジトリ (getsentry/XcodeBuildMCP) を確認
- [ ] `.mcp.json` にコピーして Claude Code で XcodeBuildMCP のツールが列挙されることを確認
- [ ] `list_schemes` などの基本ツールが動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)