### PR TITLE
refactor: establish SSOT for hardcoded values (#18)

### DIFF
--- a/GitPeek/Info.plist
+++ b/GitPeek/Info.plist
@@ -25,7 +25,7 @@
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2024 GitPeek. All rights reserved.</string>
+	<string>Copyright © 2025 GitPeek. All rights reserved.</string>
 	<key>NSDesktopFolderUsageDescription</key>
 	<string>GitPeek needs access to your Desktop folder to monitor Git repositories stored there.</string>
 	<key>NSDocumentsFolderUsageDescription</key>

--- a/GitPeek/Models/RepositoryStore.swift
+++ b/GitPeek/Models/RepositoryStore.swift
@@ -7,13 +7,11 @@ final class RepositoryStore: ObservableObject {
     @Published private(set) var repositories: [Repository] = []
     
     private let gitCommand = GitCommand()
-    private let persistenceKey = "com.gitpeek.repositories"
+    private let persistenceKey = AppConstants.Persistence.repositoriesKey
     private let fileManager = FileManager.default
-    
+
     private var saveURL: URL {
-        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("GitPeek")
-            .appendingPathComponent("repositories.json")
+        AppConstants.Persistence.repositoriesFileURL
     }
     
     init() {

--- a/GitPeek/Utils/Constants.swift
+++ b/GitPeek/Utils/Constants.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Single source of truth for shared constants across the app.
+internal enum AppConstants {
+
+    internal enum Defaults {
+        static let refreshInterval: Double = 30.0
+        static let gitCommandTimeout: Double = 30.0
+        static let gitFetchTimeout: Double = 30.0
+        static let gitPullTimeout: Double = 60.0
+        static let gitMonitorFallbackInterval: Double = 10.0
+        static let showNotifications = false
+        static let debugLogging = false
+        static let terminal = Terminal.terminal
+        static let editor = Editor.cursor
+    }
+
+    internal enum UserDefaultsKey {
+        static let refreshInterval = "refreshInterval"
+        static let showNotifications = "showNotifications"
+        static let defaultTerminal = "defaultTerminal"
+        static let defaultEditor = "defaultEditor"
+        static let gitCommandTimeout = "gitCommandTimeout"
+        static let debugLogging = "debugLogging"
+    }
+
+    internal enum Terminal {
+        static let terminal = "Terminal"
+        static let iterm2 = "iTerm2"
+        static let warp = "Warp"
+        static let hyper = "Hyper"
+    }
+
+    internal enum Editor {
+        static let cursor = "Cursor"
+        static let vscode = "VSCode"
+        static let sublime = "Sublime"
+        static let xcode = "Xcode"
+        static let nova = "Nova"
+    }
+
+    internal enum URLScheme {
+        static let vscodeFile = "vscode://file/"
+        static let sublime = "subl://"
+        static let nova = "nova://"
+
+        static func warpNewTab(path: String) -> String { "warp://action/new_tab?path=\(path)" }
+        static func hyperCD(path: String) -> String { "hyper://cd?path=\(path)" }
+    }
+
+    internal enum ExternalAppPath {
+        static let xcode = "/Applications/Xcode.app"
+        static let sourceTree = "/Applications/SourceTree.app"
+        static let bash = "/bin/bash"
+        static let open = "/usr/bin/open"
+        static let cursorCLICandidates: [String] = [
+            "/usr/local/bin/cursor",
+            "\(NSHomeDirectory())/bin/cursor",
+            "/opt/homebrew/bin/cursor"
+        ]
+    }
+
+    internal enum Persistence {
+        static let appSupportDirectoryName = "GitPeek"
+        static let repositoriesFileName = "repositories.json"
+        static let repositoriesKey = "com.gitpeek.repositories"
+
+        static var repositoriesFileURL: URL {
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent(appSupportDirectoryName)
+                .appendingPathComponent(repositoriesFileName)
+        }
+    }
+
+    internal enum GitHub {
+        static let repositoryURL = "https://github.com/ryota-kishimoto/gitpeek"
+        static let issuesURL = "\(repositoryURL)/issues"
+        static let licenseURL = "\(repositoryURL)/blob/main/LICENSE"
+    }
+
+    internal enum Layout {
+        static let refreshIntervalRange: ClosedRange<Double> = 10...300
+        static let refreshIntervalStep: Double = 10
+        static let settingsWindowWidth: CGFloat = 500
+        static let settingsWindowHeight: CGFloat = 450
+        static let aboutWindowWidth: CGFloat = 350
+        static let aboutWindowHeight: CGFloat = 450
+        static let versionFallback = "1.0.0"
+        static let copyrightText = "© 2025 GitPeek. All rights reserved."
+    }
+}

--- a/GitPeek/Utils/GitCommand.swift
+++ b/GitPeek/Utils/GitCommand.swift
@@ -54,8 +54,8 @@ final class GitCommand {
     // MARK: - Properties
     
     private var defaultTimeout: TimeInterval {
-        let stored = UserDefaults.standard.double(forKey: "gitCommandTimeout")
-        return stored > 0 ? stored : 30.0
+        let stored = UserDefaults.standard.double(forKey: AppConstants.UserDefaultsKey.gitCommandTimeout)
+        return stored > 0 ? stored : AppConstants.Defaults.gitCommandTimeout
     }
     private let cacheLock = NSLock()
     private var validationCache: [String: Bool] = [:]
@@ -140,7 +140,7 @@ final class GitCommand {
     /// - Throws: GitError if the operation fails
     func fetch(at path: String) async throws {
         try validateRepositoryPath(path)
-        _ = try await execute("git fetch --quiet", at: path, timeout: 30.0)
+        _ = try await execute("git fetch --quiet", at: path, timeout: AppConstants.Defaults.gitFetchTimeout)
     }
 
     /// Pulls changes from the remote repository
@@ -152,7 +152,7 @@ final class GitCommand {
 
         // Use --ff-only to prevent unwanted merges (safest option)
         // If fast-forward is not possible, it will fail with a clear message
-        let output = try await execute("git pull --ff-only", at: path, timeout: 60.0)
+        let output = try await execute("git pull --ff-only", at: path, timeout: AppConstants.Defaults.gitPullTimeout)
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     
@@ -363,7 +363,7 @@ final class GitCommand {
         let outputPipe = Pipe()
         let errorPipe = Pipe()
         
-        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.executableURL = URL(fileURLWithPath: AppConstants.ExternalAppPath.bash)
         process.arguments = ["-c", command]
         process.currentDirectoryURL = URL(fileURLWithPath: path)
         process.standardOutput = outputPipe

--- a/GitPeek/Utils/GitMonitor.swift
+++ b/GitPeek/Utils/GitMonitor.swift
@@ -20,9 +20,9 @@ final class GitMonitor: ObservableObject {
 
     init(repositoryStore: RepositoryStore, updateInterval: TimeInterval? = nil) {
         self.repositoryStore = repositoryStore
-        // Use the stored preference or default to 10 seconds for more real-time updates
-        let interval = updateInterval ?? UserDefaults.standard.double(forKey: "refreshInterval")
-        self.updateInterval = interval > 0 ? interval : 10.0
+        // Use the stored preference or fall back to the monitor's built-in interval.
+        let interval = updateInterval ?? UserDefaults.standard.double(forKey: AppConstants.UserDefaultsKey.refreshInterval)
+        self.updateInterval = interval > 0 ? interval : AppConstants.Defaults.gitMonitorFallbackInterval
 
         requestNotificationPermission()
     }
@@ -90,7 +90,7 @@ final class GitMonitor: ObservableObject {
         await store.updateAllRepositories(shouldFetch: shouldFetch)
 
         // Check for changes and send notifications
-        let showNotifications = UserDefaults.standard.bool(forKey: "showNotifications")
+        let showNotifications = UserDefaults.standard.bool(forKey: AppConstants.UserDefaultsKey.showNotifications)
         if showNotifications {
             for repo in store.repositories {
                 guard let newStatus = repo.gitStatus else { continue }

--- a/GitPeek/Utils/Logger.swift
+++ b/GitPeek/Utils/Logger.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Simple logger that respects the debugLogging user preference
 enum Logger {
     static func debug(_ message: @autoclosure () -> String) {
-        guard UserDefaults.standard.bool(forKey: "debugLogging") else { return }
+        guard UserDefaults.standard.bool(forKey: AppConstants.UserDefaultsKey.debugLogging) else { return }
         print("[GitPeek] \(message())")
     }
 

--- a/GitPeek/ViewModels/MenuBarViewModel.swift
+++ b/GitPeek/ViewModels/MenuBarViewModel.swift
@@ -147,12 +147,13 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     func openInTerminal(repository: Repository) {
-        let terminal = UserDefaults.standard.string(forKey: "defaultTerminal") ?? "Terminal"
+        let terminal = UserDefaults.standard.string(forKey: AppConstants.UserDefaultsKey.defaultTerminal)
+            ?? AppConstants.Defaults.terminal
         Logger.debug("Opening in \(terminal): \(repository.path)")
 
         let script: String
         switch terminal {
-        case "iTerm2":
+        case AppConstants.Terminal.iterm2:
             script = """
                 tell application "iTerm"
                     activate
@@ -162,24 +163,24 @@ final class MenuBarViewModel: ObservableObject {
                     end tell
                 end tell
             """
-        case "Warp":
+        case AppConstants.Terminal.warp:
             // Warp doesn't have AppleScript support, use URL scheme
             let escapedPath = repository.path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? repository.path
-            if let url = URL(string: "warp://action/new_tab?path=\(escapedPath)") {
+            if let url = URL(string: AppConstants.URLScheme.warpNewTab(path: escapedPath)) {
                 NSWorkspace.shared.open(url)
             }
             return
-        case "Hyper":
+        case AppConstants.Terminal.hyper:
             // Hyper doesn't have good AppleScript support
             let escapedPath = repository.path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? repository.path
-            if let url = URL(string: "hyper://cd?path=\(escapedPath)") {
+            if let url = URL(string: AppConstants.URLScheme.hyperCD(path: escapedPath)) {
                 NSWorkspace.shared.open(url)
             }
             return
         default: // Terminal
             let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-            task.arguments = ["-a", "Terminal", repository.path]
+            task.executableURL = URL(fileURLWithPath: AppConstants.ExternalAppPath.open)
+            task.arguments = ["-a", AppConstants.Terminal.terminal, repository.path]
 
             do {
                 try task.run()
@@ -224,41 +225,32 @@ final class MenuBarViewModel: ObservableObject {
     }
 
     func openInCursor(repository: Repository) {
-        let editor = UserDefaults.standard.string(forKey: "defaultEditor") ?? "Cursor"
+        let editor = UserDefaults.standard.string(forKey: AppConstants.UserDefaultsKey.defaultEditor)
+            ?? AppConstants.Defaults.editor
         Logger.debug("Opening in \(editor): \(repository.path)")
         let escapedPath = repository.path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? repository.path
 
         let urlString: String
         switch editor {
-        case "VSCode":
-            urlString = "vscode://file/\(escapedPath)"
-        case "Sublime":
-            urlString = "subl://\(escapedPath)"
-        case "Xcode":
+        case AppConstants.Editor.vscode:
+            urlString = "\(AppConstants.URLScheme.vscodeFile)\(escapedPath)"
+        case AppConstants.Editor.sublime:
+            urlString = "\(AppConstants.URLScheme.sublime)\(escapedPath)"
+        case AppConstants.Editor.xcode:
             // Open with Xcode using NSWorkspace
             let url = URL(fileURLWithPath: repository.path)
             NSWorkspace.shared.open(
                 [url],
-                withApplicationAt: URL(fileURLWithPath: "/Applications/Xcode.app"),
+                withApplicationAt: URL(fileURLWithPath: AppConstants.ExternalAppPath.xcode),
                 configuration: NSWorkspace.OpenConfiguration()
             )
             return
-        case "Nova":
-            urlString = "nova://\(escapedPath)"
+        case AppConstants.Editor.nova:
+            urlString = "\(AppConstants.URLScheme.nova)\(escapedPath)"
         default: // Cursor
             // First check if cursor CLI is available
-            let cursorPaths = [
-                "/usr/local/bin/cursor",
-                "\(NSHomeDirectory())/bin/cursor",
-                "/opt/homebrew/bin/cursor"
-            ]
-
-            var cursorCLI: String?
-            for path in cursorPaths {
-                if FileManager.default.fileExists(atPath: path) {
-                    cursorCLI = path
-                    break
-                }
+            let cursorCLI = AppConstants.ExternalAppPath.cursorCLICandidates.first {
+                FileManager.default.fileExists(atPath: $0)
             }
 
             if let cursorPath = cursorCLI {
@@ -279,8 +271,8 @@ final class MenuBarViewModel: ObservableObject {
 
             // Fallback: Use open command with -n flag to force new instance
             let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-            task.arguments = ["-n", "-a", "Cursor", repository.path]
+            task.executableURL = URL(fileURLWithPath: AppConstants.ExternalAppPath.open)
+            task.arguments = ["-n", "-a", AppConstants.Editor.cursor, repository.path]
 
             do {
                 try task.run()
@@ -316,7 +308,7 @@ final class MenuBarViewModel: ObservableObject {
 
     func openInSourceTree(repository: Repository) {
         let url = URL(fileURLWithPath: repository.path)
-        let sourceTreeURL = URL(fileURLWithPath: "/Applications/SourceTree.app")
+        let sourceTreeURL = URL(fileURLWithPath: AppConstants.ExternalAppPath.sourceTree)
 
         if FileManager.default.fileExists(atPath: sourceTreeURL.path) {
             NSWorkspace.shared.open(

--- a/GitPeek/Views/MenuBarView.swift
+++ b/GitPeek/Views/MenuBarView.swift
@@ -59,7 +59,7 @@ struct MenuBarView: View {
                 Text("GitPeek")
                     .font(.headline)
                     .foregroundColor(AppTheme.primaryText)
-                Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")")
+                Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? AppConstants.Layout.versionFallback)")
                     .font(.caption2)
                     .foregroundColor(AppTheme.secondaryText)
             }
@@ -338,7 +338,7 @@ struct RepositoryRowView: View {
 
                         Button("Open on GitHub", action: onOpenOnGitHub)
                         Button("Open in SourceTree", action: onOpenInSourceTree)
-                            .disabled(!FileManager.default.fileExists(atPath: "/Applications/SourceTree.app"))
+                            .disabled(!FileManager.default.fileExists(atPath: AppConstants.ExternalAppPath.sourceTree))
                         Button("Copy Branch Name", action: onCopyBranch)
 
                         if let worktrees = repository.worktrees, !worktrees.isEmpty {

--- a/GitPeek/Views/SettingsView.swift
+++ b/GitPeek/Views/SettingsView.swift
@@ -3,13 +3,19 @@ import Sparkle
 import ServiceManagement
 
 struct SettingsView: View {
-    @AppStorage("refreshInterval") private var refreshInterval: Double = 30.0
-    @AppStorage("showNotifications") private var showNotifications: Bool = false
+    @AppStorage(AppConstants.UserDefaultsKey.refreshInterval)
+    private var refreshInterval: Double = AppConstants.Defaults.refreshInterval
+    @AppStorage(AppConstants.UserDefaultsKey.showNotifications)
+    private var showNotifications: Bool = AppConstants.Defaults.showNotifications
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
-    @AppStorage("defaultTerminal") private var defaultTerminal: String = "Terminal"
-    @AppStorage("defaultEditor") private var defaultEditor: String = "Cursor"
-    @AppStorage("gitCommandTimeout") private var gitCommandTimeout: Double = 30.0
-    @AppStorage("debugLogging") private var debugLogging: Bool = false
+    @AppStorage(AppConstants.UserDefaultsKey.defaultTerminal)
+    private var defaultTerminal: String = AppConstants.Defaults.terminal
+    @AppStorage(AppConstants.UserDefaultsKey.defaultEditor)
+    private var defaultEditor: String = AppConstants.Defaults.editor
+    @AppStorage(AppConstants.UserDefaultsKey.gitCommandTimeout)
+    private var gitCommandTimeout: Double = AppConstants.Defaults.gitCommandTimeout
+    @AppStorage(AppConstants.UserDefaultsKey.debugLogging)
+    private var debugLogging: Bool = AppConstants.Defaults.debugLogging
     
     @State private var showingAbout = false
     @State private var showingCacheCleared = false
@@ -46,7 +52,7 @@ struct SettingsView: View {
                     }
             }
         }
-        .frame(width: 500, height: 450)
+        .frame(width: AppConstants.Layout.settingsWindowWidth, height: AppConstants.Layout.settingsWindowHeight)
     }
     
     // MARK: - General Settings
@@ -56,7 +62,11 @@ struct SettingsView: View {
             Section {
                 HStack {
                     Text("Refresh Interval:")
-                    Slider(value: $refreshInterval, in: 10...300, step: 10)
+                    Slider(
+                        value: $refreshInterval,
+                        in: AppConstants.Layout.refreshIntervalRange,
+                        step: AppConstants.Layout.refreshIntervalStep
+                    )
                         .frame(width: 200)
                     Text("\(Int(refreshInterval)) seconds")
                         .frame(width: 80, alignment: .trailing)
@@ -107,18 +117,18 @@ struct SettingsView: View {
         Form {
             Section {
                 Picker("Default Terminal:", selection: $defaultTerminal) {
-                    Text("Terminal").tag("Terminal")
-                    Text("iTerm2").tag("iTerm2")
-                    Text("Warp").tag("Warp")
-                    Text("Hyper").tag("Hyper")
+                    Text("Terminal").tag(AppConstants.Terminal.terminal)
+                    Text("iTerm2").tag(AppConstants.Terminal.iterm2)
+                    Text("Warp").tag(AppConstants.Terminal.warp)
+                    Text("Hyper").tag(AppConstants.Terminal.hyper)
                 }
-                
+
                 Picker("Default Editor:", selection: $defaultEditor) {
-                    Text("Cursor").tag("Cursor")
-                    Text("VSCode").tag("VSCode")
-                    Text("Sublime Text").tag("Sublime")
-                    Text("Xcode").tag("Xcode")
-                    Text("Nova").tag("Nova")
+                    Text("Cursor").tag(AppConstants.Editor.cursor)
+                    Text("VSCode").tag(AppConstants.Editor.vscode)
+                    Text("Sublime Text").tag(AppConstants.Editor.sublime)
+                    Text("Xcode").tag(AppConstants.Editor.xcode)
+                    Text("Nova").tag(AppConstants.Editor.nova)
                 }
             } header: {
                 Text("External Applications")
@@ -177,24 +187,21 @@ struct SettingsView: View {
     // MARK: - Actions
     
     private func resetToDefaults() {
-        refreshInterval = 30.0
-        showNotifications = false
+        refreshInterval = AppConstants.Defaults.refreshInterval
+        showNotifications = AppConstants.Defaults.showNotifications
         if launchAtLogin {
             launchAtLogin = false
             try? SMAppService.mainApp.unregister()
         }
-        defaultTerminal = "Terminal"
-        defaultEditor = "Cursor"
-        gitCommandTimeout = 30.0
-        debugLogging = false
+        defaultTerminal = AppConstants.Defaults.terminal
+        defaultEditor = AppConstants.Defaults.editor
+        gitCommandTimeout = AppConstants.Defaults.gitCommandTimeout
+        debugLogging = AppConstants.Defaults.debugLogging
     }
-    
+
     private func clearCache() {
         let fileManager = FileManager.default
-        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-        let cacheFile = appSupport
-            .appendingPathComponent("GitPeek")
-            .appendingPathComponent("repositories.json")
+        let cacheFile = AppConstants.Persistence.repositoriesFileURL
 
         if fileManager.fileExists(atPath: cacheFile.path) {
             try? fileManager.removeItem(at: cacheFile)
@@ -216,7 +223,7 @@ struct AboutView: View {
                 .font(.largeTitle)
                 .fontWeight(.bold)
             
-            Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0")")
+            Text("Version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? AppConstants.Layout.versionFallback)")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
             
@@ -229,13 +236,13 @@ struct AboutView: View {
                 .padding(.vertical)
             
             VStack(alignment: .leading, spacing: 8) {
-                if let url = URL(string: "https://github.com/ryota-kishimoto/gitpeek") {
+                if let url = URL(string: AppConstants.GitHub.repositoryURL) {
                     Link("GitHub Repository", destination: url)
                 }
-                if let url = URL(string: "https://github.com/ryota-kishimoto/gitpeek/issues") {
+                if let url = URL(string: AppConstants.GitHub.issuesURL) {
                     Link("Report an Issue", destination: url)
                 }
-                if let url = URL(string: "https://github.com/ryota-kishimoto/gitpeek/blob/main/LICENSE") {
+                if let url = URL(string: AppConstants.GitHub.licenseURL) {
                     Link("License: MIT", destination: url)
                 }
             }
@@ -250,17 +257,17 @@ struct AboutView: View {
                 .padding(.bottom, 8)
             }
             
-            Text("© 2025 GitPeek. All rights reserved.")
+            Text(AppConstants.Layout.copyrightText)
                 .font(.caption)
                 .foregroundColor(.secondary)
-            
+
             Button("Close") {
                 isPresented = false
             }
             .padding(.bottom)
         }
         .padding(20)
-        .frame(width: 350, height: 450)
+        .frame(width: AppConstants.Layout.aboutWindowWidth, height: AppConstants.Layout.aboutWindowHeight)
     }
 }
 

--- a/build.sh
+++ b/build.sh
@@ -34,56 +34,33 @@ fi
 echo "🔧 Fixing rpath..."
 install_name_tool -add_rpath "@executable_path/../Frameworks" GitPeek.app/Contents/MacOS/GitPeek 2>/dev/null || true
 
-# Get version from source Info.plist  
-VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "GitPeek/Info.plist" 2>/dev/null || echo "1.0.0")
+# Start from the source Info.plist so there is a single source of truth for
+# things like Sparkle keys, copyright, and usage descriptions. Then patch the
+# fields that can't use build-setting variables at runtime (CFBundleExecutable,
+# CFBundleIdentifier, LSMinimumSystemVersion).
+SOURCE_PLIST="GitPeek/Info.plist"
+DEST_PLIST="GitPeek.app/Contents/Info.plist"
 
-# Create Info.plist
-cat > GitPeek.app/Contents/Info.plist << EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>CFBundleExecutable</key>
-    <string>GitPeek</string>
-    <key>CFBundleIconFile</key>
-    <string>AppIcon</string>
-    <key>CFBundleIdentifier</key>
-    <string>com.gitpeek.GitPeek</string>
-    <key>CFBundleName</key>
-    <string>GitPeek</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>CFBundleShortVersionString</key>
-    <string>${VERSION}</string>
-    <key>CFBundleVersion</key>
-    <string>${VERSION}</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>13.0</string>
-    <key>LSUIElement</key>
-    <true/>
-    <key>NSHighResolutionCapable</key>
-    <true/>
-    <key>NSSupportsAutomaticTermination</key>
-    <false/>
-    <key>NSDesktopFolderUsageDescription</key>
-    <string>GitPeek needs access to your Desktop folder to monitor Git repositories stored there.</string>
-    <key>NSDocumentsFolderUsageDescription</key>
-    <string>GitPeek needs access to your Documents folder to monitor Git repositories stored there.</string>
-    <key>NSDownloadsFolderUsageDescription</key>
-    <string>GitPeek needs access to your Downloads folder to monitor Git repositories stored there.</string>
-    <key>NSRemovableVolumesUsageDescription</key>
-    <string>GitPeek needs access to removable volumes to monitor Git repositories stored there.</string>
-    <key>SUFeedURL</key>
-    <string>https://raw.githubusercontent.com/ryota-kishimoto/gitpeek/main/appcast.xml</string>
-    <key>SUEnableAutomaticChecks</key>
-    <true/>
-    <key>SUScheduledCheckInterval</key>
-    <integer>86400</integer>
-    <key>SUPublicEDKey</key>
-    <string>VuF1RDfpkALoNuceWkjdqQC8tKsTRcPEBgWnD1iIkOY=</string>
-</dict>
-</plist>
-EOF
+VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$SOURCE_PLIST" 2>/dev/null || echo "1.0.0")
+
+cp "$SOURCE_PLIST" "$DEST_PLIST"
+
+plist_set() {
+    local key="$1"
+    local type="$2"
+    local value="$3"
+    /usr/libexec/PlistBuddy -c "Set :$key $value" "$DEST_PLIST" 2>/dev/null \
+        || /usr/libexec/PlistBuddy -c "Add :$key $type $value" "$DEST_PLIST"
+}
+
+plist_set "CFBundleExecutable" "string" "GitPeek"
+plist_set "CFBundleIdentifier" "string" "com.gitpeek.GitPeek"
+plist_set "CFBundleName" "string" "GitPeek"
+plist_set "CFBundlePackageType" "string" "APPL"
+plist_set "CFBundleShortVersionString" "string" "$VERSION"
+plist_set "CFBundleVersion" "string" "$VERSION"
+plist_set "LSMinimumSystemVersion" "string" "13.0"
+plist_set "NSSupportsAutomaticTermination" "bool" "false"
 
 # Generate all icons from SVG source
 ICON_SVG="gitpeek-icon.svg"


### PR DESCRIPTION
## Summary
- Introduce `GitPeek/Utils/Constants.swift` (`AppConstants` namespace) as the single source of truth for defaults, UserDefaults keys, external app paths/URL schemes, GitHub URLs, persistence paths, and layout metrics.
- Migrate all call sites (`SettingsView`, `MenuBarView`, `MenuBarViewModel`, `RepositoryStore`, `GitCommand`, `GitMonitor`, `Logger`) off string/number literals.
- Align the 2024/2025 copyright mismatch (`Info.plist` now matches `SettingsView`).
- Stop duplicating Sparkle config in `build.sh`: it now copies the source `Info.plist` and only patches build-specific fields via `PlistBuddy`, so `SUFeedURL`/`SUPublicEDKey`/`SUScheduledCheckInterval`/usage descriptions live in one place.

Closes #18.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — 37/41 pass; the 4 failing `ViewSnapshotTests` fail identically on `main` (pre-existing snapshot drift, unrelated to this refactor)
- [x] `build.sh` plist synthesis smoke-tested with `PlistBuddy` against the real `Info.plist` — Sparkle keys, copyright, and usage descriptions are correctly inherited
- [ ] Manual launch of the built `.app` (not done here — no UI change is expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)