### PR TITLE
fix: render menu bar icon with rsvg-convert (#19 partial)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,10 +93,19 @@ else
 fi
 
 if [ -f "$MENUBAR_SVG" ]; then
-    # Menu bar icon (black template, transparent)
+    # Menu bar icon (black template, transparent).
+    # rsvg-convert handles stroke-width and complex beziers more faithfully
+    # than ImageMagick at tiny sizes, so the 18/36px output is slightly less
+    # fuzzy. Falls back to magick if rsvg-convert is unavailable.
     echo "🎨 Copying menu bar icon..."
-    magick -background none "$MENUBAR_SVG" -resize 18x18 PNG32:GitPeek.app/Contents/Resources/MenuBarIcon.png
-    magick -background none "$MENUBAR_SVG" -resize 36x36 PNG32:GitPeek.app/Contents/Resources/MenuBarIcon@2x.png
+    if command -v rsvg-convert >/dev/null 2>&1; then
+        rsvg-convert -w 18 -h 18 "$MENUBAR_SVG" -o GitPeek.app/Contents/Resources/MenuBarIcon.png
+        rsvg-convert -w 36 -h 36 "$MENUBAR_SVG" -o GitPeek.app/Contents/Resources/MenuBarIcon@2x.png
+    else
+        echo "⚠️  rsvg-convert not found, falling back to magick (may look fuzzier)"
+        magick -background none "$MENUBAR_SVG" -resize 18x18 PNG32:GitPeek.app/Contents/Resources/MenuBarIcon.png
+        magick -background none "$MENUBAR_SVG" -resize 36x36 PNG32:GitPeek.app/Contents/Resources/MenuBarIcon@2x.png
+    fi
 else
     echo "⚠️  gitpeek-menubar.svg not found, skipping menu bar icon"
 fi


### PR DESCRIPTION
## Summary
- Swap `magick` → `rsvg-convert` in `build.sh` for `MenuBarIcon.png` / `@2x.png`. rsvg-convert handles the stroke-width and small-bezier geometry more faithfully, so the 18/36px output is slightly less fuzzy — same SVG, different renderer.
- Keeps a `magick` fallback branch so environments without librsvg still build.

## Scope notes (re: #19)
- **Partial fix only.** The root cause of the blur is the complex bezier geometry in `gitpeek-menubar.svg` (vtracer-generated). Swapping renderers nudges it in the right direction but doesn't fully resolve it. A proper fix would simplify the SVG to hand-crafted geometric primitives, which changes the design — out of scope here.
- **Local-build only.** `.github/workflows/release.yml` doesn't rasterize `MenuBarIcon.png` at all, so released binaries fall through to the SF Symbol path in `GitPeekApp.swift:48-49`. This PR only improves builds run via `./build.sh` locally. CI consistency is a separate concern.

## Test plan
- [x] `bash -n build.sh` — syntax OK
- [x] Smoke-tested `rsvg-convert` command against `gitpeek-menubar.svg`; produces valid 18x18 / 36x36 PNG32 images
- [ ] Run `./build.sh` locally and eyeball `GitPeek.app` in the menu bar (light + dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)