### PR TITLE
chore: ignore local scratch files (.claude lock, icon-experiments)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,9 @@ temp/
 
 # Claude Code MCP (per-developer; see .mcp.json.example)
 .mcp.json
+
+# Claude Code scheduled task lock (per-developer)
+.claude/scheduled_tasks.lock
+
+# Icon design experiments (local scratch)
+icon-experiments/


### PR DESCRIPTION
## Summary
- Add `.claude/scheduled_tasks.lock` to .gitignore (per-developer Claude Code lock file)
- Add `icon-experiments/` to .gitignore (local icon design scratch directory)

## Test plan
- [ ] `git status` shows clean working tree after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)