### PR TITLE
fix: avoid index.lock contention when polling repository status

### DIFF
--- a/GitPeek/Models/RepositoryStore.swift
+++ b/GitPeek/Models/RepositoryStore.swift
@@ -80,18 +80,18 @@ final class RepositoryStore: ObservableObject {
                 repositories[index] = updated
             }
 
-            // Optionally fetch in background (slow, but updates remote info)
+            // Optionally fetch (slow, but updates remote info).
+            // Awaited rather than detached so that a slow fetch delays this
+            // refresh cycle instead of overlapping with the next one.
             if shouldFetch {
-                Task { @MainActor in
-                    try? await gitCommand.fetch(at: path)
-                    // Re-check commit difference after fetch
-                    if let newCommitDiff = try? await gitCommand.getCommitDifference(at: path) {
-                        self.applyCommitDifference(
-                            id: id,
-                            behind: newCommitDiff.behind,
-                            ahead: newCommitDiff.ahead
-                        )
-                    }
+                try? await gitCommand.fetch(at: path)
+                // Re-check commit difference after fetch
+                if let newCommitDiff = try? await gitCommand.getCommitDifference(at: path) {
+                    applyCommitDifference(
+                        id: id,
+                        behind: newCommitDiff.behind,
+                        ahead: newCommitDiff.ahead
+                    )
                 }
             }
         } catch {

--- a/GitPeek/Utils/GitCommand.swift
+++ b/GitPeek/Utils/GitCommand.swift
@@ -94,7 +94,7 @@ final class GitCommand {
     func getStatus(at path: String) async throws -> GitStatus {
         try validateRepositoryPath(path)
         
-        let output = try await execute("git status --porcelain", at: path)
+        let output = try await execute("git --no-optional-locks status --porcelain", at: path)
         return parseGitStatusOutput(output)
     }
     

--- a/GitPeekTests/Unit/GitCommandTests.swift
+++ b/GitPeekTests/Unit/GitCommandTests.swift
@@ -50,6 +50,51 @@ final class GitCommandTests: XCTestCase {
         XCTAssertTrue(status.untrackedFiles.isEmpty, "Should have no untracked files")
     }
     
+    func testGetStatus_doesNotRewriteIndex() async throws {
+        // Arrange
+        // `git status` refreshes stale stat info by rewriting .git/index, which
+        // takes .git/index.lock. That races with the user's own `git checkout`
+        // and makes it fail with "Unable to create '.../index.lock'", so the
+        // monitoring path must leave the index untouched.
+        let gitCommand = GitCommand()
+        let file = testRepoPath + "/tracked.txt"
+        try "content".write(toFile: file, atomically: true, encoding: .utf8)
+        try runGit(["add", "tracked.txt"])
+        try runGit(["-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "-m", "init"])
+
+        // Make the cached stat info stale so a refresh would be triggered.
+        let indexPath = testRepoPath + "/.git/index"
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 0)],
+            ofItemAtPath: file
+        )
+        let mtimeBefore = try indexModificationDate(at: indexPath)
+
+        // Act
+        _ = try await gitCommand.getStatus(at: testRepoPath)
+
+        // Assert
+        let mtimeAfter = try indexModificationDate(at: indexPath)
+        XCTAssertEqual(
+            mtimeBefore, mtimeAfter,
+            "getStatus must not rewrite .git/index, otherwise it competes for index.lock"
+        )
+    }
+
+    private func indexModificationDate(at path: String) throws -> Date {
+        let attributes = try FileManager.default.attributesOfItem(atPath: path)
+        return try XCTUnwrap(attributes[.modificationDate] as? Date)
+    }
+
+    private func runGit(_ arguments: [String]) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = URL(fileURLWithPath: testRepoPath)
+        try process.run()
+        process.waitUntilExit()
+    }
+
     func testIsValidRepository_returnsTrueForGitRepo() throws {
         // Act
         let isValid = GitCommand.isValidRepository(at: testRepoPath)


### PR DESCRIPTION
## 概要

30秒ごとの監視で走る `git status` が、ユーザー自身の git 操作を
`fatal: Unable to create '.../.git/index.lock': File exists` で失敗させることがある。

`git status` はワーキングツリー走査で古くなった stat 情報を見つけると、
**index を書き戻すために `.git/index.lock` を取る**（読み取り専用に見えて実際は書く）。
監視対象4リポジトリ × 30秒間隔でこれが走るため、ユーザーが `git checkout` や
`git commit` した瞬間にロックが衝突する。

## 再現

400ファイルのリポジトリで、`git status` 5並列に `git checkout` をぶつけた結果:

| status の実行方法 | checkout の失敗率 |
|---|---|
| `git status --porcelain`（現行） | **9 / 60** |
| `git --no-optional-locks status --porcelain` | **0 / 60** |

`--no-optional-locks` は「index 更新は任意」と git に伝えるフラグで、まさにこの用途
（監視ツールが index を書かないようにする）のために用意されている。

なお `git status` 側は index リフレッシュを best-effort 扱いにしており、
ロックが取れなくても黙って握り潰して exit 0 で終わる。つまり**被害を受けるのは
常にユーザー側の git コマンド**で、GitPeek 側のログには何も残らない。

## 変更内容

- `getStatus` を `git --no-optional-locks status --porcelain` に変更。
  監視ループが `.git/index` を書き換えなくなる
- `updateRepository` の fetch を detach された `Task {}` から `await` に変更。
  誰も待たないため前サイクルの fetch が次サイクルと重なり得た

`branch --show-current` / `rev-parse` / `remote get-url` / `worktree list` は
index を書かないことを確認済みのため、そのまま。

## テスト

- `testGetStatus_doesNotRewriteIndex` を追加。stat 情報を意図的に古くしてから
  `getStatus` を呼び、`.git/index` の mtime が変わらないことを検証する
  （修正前は fail、修正後は pass を確認）
- 既存の unit テストは全て pass（38件）
- `ViewSnapshotTests` の4件は main でも同様に失敗する既存の失敗で、本 PR とは無関係
